### PR TITLE
remove rpi dep

### DIFF
--- a/custom_components/ha-rpi_gpio_pwm/manifest.json
+++ b/custom_components/ha-rpi_gpio_pwm/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rpi_gpio_pwm",
   "name": "Raspberry Pi GPIO PWM",
   "documentation": "https://www.home-assistant.io/integrations/rpi_gpio_pwm",
-  "requirements": ["pwmled==1.6.10","RPi.GPIO==0.7.1a4"],
+  "requirements": ["pwmled==1.6.10"],
   "codeowners": ["@soldag"],
   "iot_class": "local_push",
   "loggers": ["adafruit_blinka", "adafruit_circuitpython_pca9685", "pwmled"],


### PR DESCRIPTION
fixes #6 - there is no real need for rpi.gpio dependency (unless I'm missing something here) and since it can't be used in python 3.10, which the newest version of HA uses, it is necessary to remove it...