### PR TITLE
Add Fan control with GPIO

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: "Lint"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: "Lint"
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **This is a spin-off from the original Home Assistant integration which was marked as deprecated and will be removed in Home Assistant Core 2022.4.**
 
-The rpi_gpio_pwm platform allows to control multiple lights using pulse-width modulation, for example LED strips. It supports one-color LEDs driven by GPIOs of a Raspberry Pi (same host or remote)
+The rpi_gpio_pwm platform allows to control multiple lights or fans using pulse-width modulation, for example LED strips. It supports one-color LEDs or fans driven by GPIOs of a Raspberry Pi (same host or remote)
 For controlling the GPIOs, the platform connects to the pigpio-daemon (http://abyz.me.uk/rpi/pigpio/pigpiod.html), which must be running. On Raspbian Jessie 2016-05-10 or newer the pigpio library is already included. On other operating systems it needs to be installed first (see installation instructions: https://github.com/soldag/python-pwmled#installation).
 
 For Home Assistant this daemon can be installed as an add-on (https://github.com/Poeschl/Hassio-Addons/tree/master/pigpio).
@@ -21,7 +21,7 @@ Copy the `ha-rpi_gpio_pwm` folder and all of its contents into your Home Assista
 To enable this platform, add the following lines to your configuration.yaml:
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry for lights
 light:
   - platform: rpi_gpio_pwm
     leds:
@@ -29,16 +29,27 @@ light:
         pin: 17
         unique_id: thisismyuniqueid
 ```
+```yaml
+# Example configuration.yaml entry for fans
+fan:
+  - platform: rpi_gpio_pwm
+    fans:
+      - name: RPI Cooling Fan
+        pin: 12
+        unique_id: thisismyuniqueid
+```
 # CONFIGURATION VARIABLES
-- **leds** list *(REQUIRED)*: Can contain multiple LEDs.
+- **leds** list *(REQUIRED if lights)*: Can contain multiple LEDs.
 
-- **name** string *(REQUIRED)*: The name of the LED.
+- **fans** list *(REQUIRED if fans)*: Can contain multiple FANs.
 
-- **pin** integer *(REQUIRED)*: The pin connected to the LED as a list.
+- **name** string *(REQUIRED)*: The name of the LED for light config or the name of the FAN for fan config.
 
-- **unique_id** string *(optional)*: An ID that uniquely identifies this LED. Set this to a unique value to allow customization through the UI.
+- **pin** integer *(REQUIRED)*: The pin connected to the LED as a list for light config or the pin connected to the FAN for fan config..
 
-- **frequency** integer *(optional, default: 100)*: The PWM frequency.
+- **unique_id** string *(optional)*: An ID that uniquely identifies this LED or FAN. Set this to a unique value to allow customization through the UI.
+
+- **frequency** integer *(optional, default: 100)*: The PWM frequency for light config.
 
 - **host** string *(optional, default: localhost)*: The remote host address for the GPIO driver.
 

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -1,0 +1,147 @@
+"""Support for Fan that can be controlled using PWM."""
+from __future__ import annotations
+
+import logging
+
+from gpiozero import PWMOutputDevice
+from gpiozero.pins.pigpio import PiGPIOFactory
+
+import voluptuous as vol
+
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    PLATFORM_SCHEMA,
+    FanEntityFeature,
+    FanEntity,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_NAME, STATE_ON, CONF_UNIQUE_ID
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FANS = "fans"
+CONF_PIN = "pin"
+
+DEFAULT_PERCENTAGE = 100
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 8888
+
+SUPPORT_SIMPLE_FAN = FanEntityFeature.SET_SPEED
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_FANS): vol.All(
+            cv.ensure_list,
+            [
+                {
+                    vol.Required(CONF_NAME): cv.string,
+                    vol.Required(CONF_PIN): cv.positive_int,
+                    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+                    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                    vol.Optional(CONF_UNIQUE_ID): cv.string,
+                }
+            ],
+        )
+    }
+)
+
+
+def setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the PWM FAN."""
+    fans = []
+    for fan_conf in config[CONF_FANS]:
+        pin = fan_conf[CONF_PIN]
+        opt_args = {}
+        opt_args["pin_factory"] = PiGPIOFactory(host=fan_conf[CONF_HOST], port= fan_conf[CONF_PORT])
+        if CONF_UNIQUE_ID in fan_conf:
+            fan = PwmSimpleFan(PWMOutputDevice(pin, **opt_args), fan_conf[CONF_NAME], fan_conf[CONF_UNIQUE_ID])
+        else:
+            fan = PwmSimpleFan(PWMOutputDevice(pin, **opt_args), fan_conf[CONF_NAME])
+        fans.append(fan)
+
+    add_entities(fans)
+
+
+class PwmSimpleFan(FanEntity, RestoreEntity):
+    """Representation of a simple PWM FAN."""
+
+    def __init__(self, fan, name, unique_id):
+        """Initialize PWM FAN."""
+        self._fan = fan
+        self._name = name
+        self._unique_id = unique_id
+        self._is_on = False
+        self._percentage = DEFAULT_PERCENTAGE
+
+    async def async_added_to_hass(self):
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        if last_state := await self.async_get_last_state():
+            self._is_on = last_state.state == STATE_ON
+            self._percentage = last_state.attributes.get(
+                "percentage", DEFAULT_PERCENTAGE
+            )
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the group."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._is_on
+
+    @property
+    def percentage(self):
+        """Return the percentage property."""
+        return self._percentage
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_SIMPLE_FAN
+
+    def turn_on(self, percentage: Optional[int] = None, preset_mode: Optional[str] = None, **kwargs: Any) -> None:
+        """Turn on the fan."""
+        if percentage != None:
+            self._percentage = percentage
+        elif ATTR_PERCENTAGE in kwargs:
+            self._percentage = kwargs[ATTR_PERCENTAGE]
+        self._fan.value = self._percentage / 100
+        self._is_on = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn the fan off."""
+        if self.is_on:
+            self._fan.off()
+        self._is_on = False
+        self.schedule_update_ha_state()
+
+    def set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        self._percentage = percentage
+        self._fan.value = self._percentage / 100
+        self._is_on = True
+        self.schedule_update_ha_state()

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -122,9 +122,9 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         """Flag supported features."""
         return SUPPORT_SIMPLE_FAN
 
-    def turn_on(self, percentage: Optional[int] = None, preset_mode: Optional[str] = None, **kwargs: Any) -> None:
+    def turn_on(self, percentage: None, preset_mode: None, **kwargs) -> None:
         """Turn on the fan."""
-        if percentage != None:
+        if percentage is not None:
             self._percentage = percentage
         elif ATTR_PERCENTAGE in kwargs:
             self._percentage = kwargs[ATTR_PERCENTAGE]
@@ -132,7 +132,7 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         self._is_on = True
         self.schedule_update_ha_state()
 
-    def turn_off(self, **kwargs: Any) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn the fan off."""
         if self.is_on:
             self._fan.off()

--- a/info.md
+++ b/info.md
@@ -2,7 +2,7 @@
 
 **This is a spin-off from the original Home Assistant integration which was marked as deprecated and will be removed in Home Assistant Core 2022.4.**
 
-The rpi_gpio_pwm platform allows to control multiple lights using pulse-width modulation, for example LED strips. It supports one-color LEDs driven by GPIOs of a Raspberry Pi (same host or remote)
+The rpi_gpio_pwm platform allows to control multiple lights or fans using pulse-width modulation, for example LED strips. It supports one-color LEDs or fans driven by GPIOs of a Raspberry Pi (same host or remote)
 For controlling the GPIOs, the platform connects to the pigpio-daemon (http://abyz.me.uk/rpi/pigpio/pigpiod.html), which must be running. On Raspbian Jessie 2016-05-10 or newer the pigpio library is already included. On other operating systems it needs to be installed first (see installation instructions: https://github.com/soldag/python-pwmled#installation).
 
 For Home Assistant this daemon can be installed as an add-on (https://github.com/Poeschl/Hassio-Addons/tree/master/pigpio).
@@ -21,7 +21,7 @@ Copy the `ha-rpi_gpio_pwm` folder and all of its contents into your Home Assista
 To enable this platform, add the following lines to your configuration.yaml:
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry for lights
 light:
   - platform: rpi_gpio_pwm
     leds:
@@ -29,16 +29,27 @@ light:
         pin: 17
         unique_id: thisismyuniqueid
 ```
+```yaml
+# Example configuration.yaml entry for fans
+fan:
+  - platform: rpi_gpio_pwm
+    fans:
+      - name: RPI Cooling Fan
+        pin: 12
+        unique_id: thisismyuniqueid
+```
 # CONFIGURATION VARIABLES
-- **leds** list *(REQUIRED)*: Can contain multiple LEDs.
+- **leds** list *(REQUIRED if lights)*: Can contain multiple LEDs.
 
-- **name** string *(REQUIRED)*: The name of the LED.
+- **fans** list *(REQUIRED if fans)*: Can contain multiple FANs.
 
-- **pin** integer *(REQUIRED)*: The pin connected to the LED as a list.
+- **name** string *(REQUIRED)*: The name of the LED for light config or the name of the FAN for fan config.
 
-- **unique_id** string *(optional)*: An ID that uniquely identifies this LED. Set this to a unique value to allow customization through the UI.
+- **pin** integer *(REQUIRED)*: The pin connected to the LED as a list for light config or the pin connected to the FAN for fan config..
 
-- **frequency** integer *(optional, default: 100)*: The PWM frequency.
+- **unique_id** string *(optional)*: An ID that uniquely identifies this LED or FAN. Set this to a unique value to allow customization through the UI.
+
+- **frequency** integer *(optional, default: 100)*: The PWM frequency for light config.
 
 - **host** string *(optional, default: localhost)*: The remote host address for the GPIO driver.
 


### PR DESCRIPTION
Hello, first of all thank you very much for all your work!

#### Description
I added the possibility of controlling a fan via GPIO

I use your integration on my HomeAssistant on raspberry Pi4 to control the fan speed with PWM plugged into the GPIO ports.
But with your integration it appears as a light in the interface of my HomeAssistant.
I would like to be able to control it like a fan in my automations, my scripts and generally define it as a fan in HA since it is one.
This is why I based myself on your excellent work on the lights to add the possibility of defining a device connected to a GPIO port as a fan.
I managed to control my fan with the GPIO ports by following the explanations found on many different forums. This is why I think this new feature can be useful to many people who also use your integration to control a fan.
thanks again

#### Resume
Bug fix: no
New feature: yes
Fixed tickets: not for the moment