### PR TITLE
Update for ha core 2025.1 and 2025.3

### DIFF
--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -12,8 +12,8 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
-    SUPPORT_TRANSITION,
     LightEntity,
+    LightEntityFeature,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_NAME, STATE_ON, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
@@ -33,7 +33,7 @@ DEFAULT_BRIGHTNESS = 255
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8888
 
-SUPPORT_SIMPLE_LED = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+SUPPORT_SIMPLE_LED = SUPPORT_BRIGHTNESS | LightEntityFeature.TRANSITION
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
-    SUPPORT_BRIGHTNESS,
+    ColorMode,
     LightEntity,
     LightEntityFeature,
 )
@@ -33,7 +33,8 @@ DEFAULT_BRIGHTNESS = 255
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8888
 
-SUPPORT_SIMPLE_LED = SUPPORT_BRIGHTNESS | LightEntityFeature.TRANSITION
+SUPPORT_SIMPLE_LED = LightEntityFeature.TRANSITION
+COLORMODE = ColorMode.BRIGHTNESS
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -121,6 +122,16 @@ class PwmSimpleLed(LightEntity, RestoreEntity):
     def brightness(self):
         """Return the brightness property."""
         return self._brightness
+
+    @property
+    def supported_color_modes(self):
+        """Return the flag supported_color_modes property."""
+        return {COLORMODE}
+
+    @property
+    def color_mode(self):
+        """Return the color_mode property."""
+        return COLORMODE
 
     @property
     def supported_features(self):


### PR DESCRIPTION
Hi,
I updated light.py to replace SUPPORT_TRANSITION and SUPPORT_BRIGHTNESS which are two functions soon to be deprecated by the new standards requested by HA CORE.
This removes error messages that could occur when configuring a light and solve the issue report here https://github.com/RedMeKool/HA-Raspberry-pi-GPIO-PWM/issues/29