### PR TITLE
Add configuration from the integrations UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fan:
 
 - **pin** integer *(REQUIRED)*: The pin connected to the LED as a list for light config or the pin connected to the FAN for fan config..
 
-- **unique_id** string *(optional)*: An ID that uniquely identifies this LED or FAN. Set this to a unique value to allow customization through the UI.
+- **unique_id** string *(REQUIRED)*: An ID that uniquely identifies this LED or FAN. Set this to a unique value to allow customization through the UI.
 
 - **frequency** integer *(optional, default: 100)*: The PWM frequency for light config.
 

--- a/custom_components/rpi_gpio_pwm/__init__.py
+++ b/custom_components/rpi_gpio_pwm/__init__.py
@@ -1,1 +1,49 @@
 """The rpi_gpio_pwm component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, PLATFORMS
+
+
+# Transform the configEntry from config_flow into an entity
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up entity from a ConfigEntry."""
+
+    # Sets the default domain to be our domain
+    hass.data.setdefault(DOMAIN, {})
+    hass_data = dict(entry.data)
+
+    # Registers update listener to update config entry when options are updated.
+    unsub_options_update_listener = entry.add_update_listener(options_update_listener)
+    # Store a reference to the unsubscribe function to cleanup if an entry is unloaded.
+    hass_data["unsub_options_update_listener"] = unsub_options_update_listener
+
+    hass.data[DOMAIN][entry.entry_id] = hass_data
+
+    # Propagates the configEntry to all platforms declared in the integration
+    # This creates each HA object for each platform your device requires.
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def options_update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Handle options update."""
+    await hass.config_entries.async_reload(config_entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    # This is called when an entry/configured device is to be removed. The class
+    # needs to unload itself, and remove callbacks. See the classes for further
+    # details
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        # Remove config entry from domain.
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id)
+        # Remove options_update_listener.
+        entry_data["unsub_options_update_listener"]()
+
+    return unload_ok

--- a/custom_components/rpi_gpio_pwm/config_flow.py
+++ b/custom_components/rpi_gpio_pwm/config_flow.py
@@ -1,16 +1,23 @@
 """Config flow to configure rpi_gpio_pwm component."""
 
+from collections.abc import Mapping
+import copy
+import re
+from typing import Any
+
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import (
+    CONF_ENTITY_ID,
     CONF_HOST,
     CONF_NAME,
     CONF_PLATFORM,
     CONF_PORT,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import entity_registry as er, selector
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -43,6 +50,35 @@ DATA_SCHEMA_ConfigFlowFan = vol.Schema(
     }
 )
 
+DATA_SCHEMA_OptionFlowLight = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_ENTITY_ID): selector.TextSelector(
+            selector.TextSelectorConfig(
+                prefix="light.", type=selector.TextSelectorType.TEXT
+            )
+        ),
+        vol.Required(CONF_PIN): cv.positive_int,
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_FREQUENCY, default=DEFAULT_FREQUENCY): cv.positive_int,
+    }
+)
+
+DATA_SCHEMA_OptionFlowFan = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_ENTITY_ID): selector.TextSelector(
+            selector.TextSelectorConfig(
+                prefix="fan.", type=selector.TextSelectorType.TEXT
+            )
+        ),
+        vol.Required(CONF_PIN): cv.positive_int,
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    }
+)
+
 
 async def async_check_if_pin_is_used(hass: HomeAssistant, pin: int) -> str | None:
     """Check if pin is free or already use by rpi_gpio_pwm component."""
@@ -66,6 +102,53 @@ async def async_check_if_pin_is_used(hass: HomeAssistant, pin: int) -> str | Non
     return True
 
 
+async def async_get_entity_id_by_unique_id(
+    hass: HomeAssistant, PlatForm: str, Unique_ID: str | None
+) -> str | None:
+    """Get OLD entity_id in case it need to change."""
+    if Unique_ID is None:
+        return None
+    entity_registry = er.async_get(hass)
+    return entity_registry.async_get_entity_id(
+        domain=PlatForm, platform=DOMAIN, unique_id=Unique_ID
+    )
+
+
+async def update_entity_ID(
+    hass: HomeAssistant, entity_id_OLD: str, entity_id_NEW: str
+) -> None:
+    """Update entity if change in Config Flow.."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_update_entity(
+        entity_id=entity_id_OLD,
+        new_entity_id=entity_id_NEW,
+    )
+
+
+def add_suggested_values_to_schema(
+    data_schema: vol.Schema, suggested_values: Mapping[str, Any]
+) -> vol.Schema:
+    """Make a copy of the schema, populated with suggested values.
+
+    For each schema marker matching items in `suggested_values`,
+    the `suggested_value` will be set. The existing `suggested_value` will
+    be left untouched if there is no matching item.
+    """
+    schema = {}
+    for key, val in data_schema.schema.items():
+        new_key = key
+        if key in suggested_values and isinstance(key, vol.Marker):
+            # Copy the marker to not modify the flow schema
+            new_key = copy.copy(key)
+            new_key.description = {"suggested_value": suggested_values[key]}
+            if key == CONF_ENTITY_ID:
+                sugg_values = str(suggested_values[key]).replace("light.", "", 1)
+                suggested_val = sugg_values.replace("fan.", "", 1)
+                new_key.description = {"suggested_value": suggested_val}
+        schema[new_key] = val
+    return vol.Schema(schema)
+
+
 class GPIOPWMConfigFlow(ConfigFlow, domain=DOMAIN):
     """Rpi_gpio_pwm Custom config flow."""
 
@@ -73,9 +156,6 @@ class GPIOPWMConfigFlow(ConfigFlow, domain=DOMAIN):
     # Home Assistant will call your migrate method if the version changes
     VERSION = 1
     MINOR_VERSION = 1
-
-    # Define a dictionary for the information that will be entered
-    # data: Optional[dict[str, Any]]
 
     async def async_step_user(self, user_input=None):
         """Invoke when a user initiates a flow via the user interface."""
@@ -140,4 +220,133 @@ class GPIOPWMConfigFlow(ConfigFlow, domain=DOMAIN):
         # Menu to display
         return self.async_show_form(
             step_id="fan", data_schema=DATA_SCHEMA_ConfigFlowFan, errors=errors
+        )
+
+    # Declare optionFlow
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry):
+        """Get options flow for this handler."""
+        return GPIOPWMOptionsFlow(config_entry)
+
+
+class GPIOPWMOptionsFlow(OptionsFlow):
+    """Rpi_gpio_pwm Custom Option flow to modify the configuration."""
+
+    # To memorize the current config
+    config_entry: ConfigEntry = None
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initializ the option flow. We have the existing ConfigEntry as input."""
+        self.config_entry = config_entry
+        # We initialize the data with the data from the configEntry
+        self.data = config_entry.data.copy()
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        """Manage the options. Same option as configflow."""
+        errors: dict[str, str] = {}
+
+        # Stock OLD entity_id and add it to data for show it in config suggested_values in case it need to change
+        if self.config_entry.data[CONF_PLATFORM] == CONF_LIGHT:
+            PLATFORM = CONF_LIGHT
+        elif self.config_entry.data[CONF_PLATFORM] == CONF_FAN:
+            PLATFORM = CONF_FAN
+        entity_id_old = await async_get_entity_id_by_unique_id(
+            hass=self.hass,
+            PlatForm=PLATFORM,
+            Unique_ID=self.config_entry.entry_id,
+        )
+        self.data.update({CONF_ENTITY_ID: entity_id_old})
+
+        # Stock OLD pin in case it don't change
+        pin_old = self.config_entry.data.get(CONF_PIN)
+
+        if user_input is not None:
+            # Memorizes the information entered in user_input
+            self.data.update(user_input)
+
+            # Check if the pin changes and check if it is free if it is
+            if pin_old != self.data[CONF_PIN]:
+                pin_is_free = await async_check_if_pin_is_used(
+                    hass=self.hass, pin=self.data[CONF_PIN]
+                )
+                if pin_is_free is False:
+                    errors[CONF_PIN] = "pin_used"
+
+            # Check format for Entity_ID
+            if self.config_entry.data[CONF_PLATFORM] == CONF_LIGHT:
+                if re.match(r"^[_A-Za-z0-9]+$", self.data[CONF_ENTITY_ID]) is None:
+                    errors[CONF_ENTITY_ID] = "light_bad_EntityID_format"
+                self.data[CONF_ENTITY_ID] = "light." + self.data[CONF_ENTITY_ID]
+            elif self.config_entry.data[CONF_PLATFORM] == CONF_FAN:
+                if re.match(r"^[_A-Za-z0-9]+$", self.data[CONF_ENTITY_ID]) is None:
+                    errors[CONF_ENTITY_ID] = "fan_bad_EntityID_format"
+                self.data[CONF_ENTITY_ID] = "fan." + self.data[CONF_ENTITY_ID]
+
+            if not errors:
+                # Update the entity
+                if self.config_entry.data[CONF_PLATFORM] == CONF_LIGHT:
+                    TITLE = "GPIO " + str(self.data[CONF_PIN]) + " PWM " + CONF_LIGHT
+                elif self.config_entry.data[CONF_PLATFORM] == CONF_FAN:
+                    TITLE = "GPIO " + str(self.data[CONF_PIN]) + " PWM " + CONF_FAN
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    title=TITLE,
+                    data=self.data,
+                )
+                # Reload the entry
+                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+
+                # Updates the entity_id if it changes
+                if entity_id_old != self.data[CONF_ENTITY_ID]:
+                    await update_entity_ID(
+                        hass=self.hass,
+                        entity_id_OLD=entity_id_old,
+                        entity_id_NEW=self.data[CONF_ENTITY_ID],
+                    )
+                    await self.notify_update_entity_id(
+                        entity_id_OLD=entity_id_old,
+                        entity_id_NEW=self.data[CONF_ENTITY_ID],
+                    )
+                    # We do nothing in the options object in the configEntry
+                    return self.async_create_entry(title=None, data=None)
+
+                # We do nothing in the options object in the configEntry
+                return self.async_create_entry(title=None, data=None)
+
+        # Menu to display
+        if self.data[CONF_PLATFORM] == CONF_LIGHT:
+            return self.async_show_form(
+                step_id="init",
+                data_schema=add_suggested_values_to_schema(
+                    data_schema=DATA_SCHEMA_OptionFlowLight,
+                    suggested_values=self.data,
+                ),
+                errors=errors,
+            )
+        elif self.data[CONF_PLATFORM] == CONF_FAN:
+            return self.async_show_form(
+                step_id="init",
+                data_schema=add_suggested_values_to_schema(
+                    data_schema=DATA_SCHEMA_OptionFlowFan,
+                    suggested_values=self.data,
+                ),
+                errors=errors,
+            )
+
+    async def notify_update_entity_id(
+        self, entity_id_OLD: str, entity_id_NEW: str
+    ) -> None:
+        """Call a SERVICE for update entity if change in Config Flow."""
+        self.config_entry.async_create_task(
+            hass=self.hass,
+            target=self.hass.services.async_call(
+                domain="notify",
+                service="persistent_notification",
+                service_data={
+                    "message": f"The entity_id has been changed {entity_id_OLD} --> {entity_id_NEW}"
+                },
+                target={},
+                blocking=True,
+            ),
         )

--- a/custom_components/rpi_gpio_pwm/config_flow.py
+++ b/custom_components/rpi_gpio_pwm/config_flow.py
@@ -1,0 +1,143 @@
+"""Config flow to configure rpi_gpio_pwm component."""
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PLATFORM,
+    CONF_PORT,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    CONF_FAN,
+    CONF_FREQUENCY,
+    CONF_LIGHT,
+    CONF_PIN,
+    DEFAULT_FREQUENCY,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DOMAIN,
+)
+
+DATA_SCHEMA_ConfigFlowLight = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_PIN): cv.positive_int,
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_FREQUENCY, default=DEFAULT_FREQUENCY): cv.positive_int,
+    }
+)
+
+DATA_SCHEMA_ConfigFlowFan = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_PIN): cv.positive_int,
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    }
+)
+
+
+async def async_check_if_pin_is_used(hass: HomeAssistant, pin: int) -> str | None:
+    """Check if pin is free or already use by rpi_gpio_pwm component."""
+
+    # Load all already configured config_entries (in .storage/core.config_entries)
+    config_entries_data = await hass.config_entries._store.async_load()
+
+    # Create a list of pins already in use
+    pin_list = []
+    for i in config_entries_data:
+        if i == "entries":
+            for j in config_entries_data[i]:
+                if j.get("domain") == DOMAIN:
+                    for k in j:
+                        if k == "data":
+                            pin_list.extend([j[k].get(CONF_PIN)])
+
+    # Return True if pin is free, else False
+    if pin in pin_list:
+        return False
+    return True
+
+
+class GPIOPWMConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Rpi_gpio_pwm Custom config flow."""
+
+    # The schema version of the entries that it creates
+    # Home Assistant will call your migrate method if the version changes
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    # Define a dictionary for the information that will be entered
+    # data: Optional[dict[str, Any]]
+
+    async def async_step_user(self, user_input=None):
+        """Invoke when a user initiates a flow via the user interface."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["light", "fan"],
+        )
+
+    async def async_step_light(self, user_input: dict | None = None) -> FlowResult:
+        """Invoke when a user initiates a flow via the user interface."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Memorizes the information entered in user_input
+            self.data = user_input
+            # Stock platform in the user inputs data
+            self.data[CONF_PLATFORM] = CONF_LIGHT
+
+            # Check if selected pin is free
+            pin_is_free = await async_check_if_pin_is_used(
+                hass=self.hass, pin=self.data[CONF_PIN]
+            )
+            if pin_is_free is False:
+                errors[CONF_PIN] = "pin_used"
+
+            if not errors:
+                # Create the entity
+                return self.async_create_entry(
+                    title="GPIO " + str(self.data[CONF_PIN]) + " PWM " + CONF_LIGHT,
+                    data=self.data,
+                )
+
+        # Menu to display
+        return self.async_show_form(
+            step_id="light", data_schema=DATA_SCHEMA_ConfigFlowLight, errors=errors
+        )
+
+    async def async_step_fan(self, user_input: dict | None = None) -> FlowResult:
+        """Invoke when a user initiates a flow via the user interface."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Memorizes the information entered in user_input
+            self.data = user_input
+            # Stock platform in the user inputs data
+            self.data[CONF_PLATFORM] = CONF_FAN
+
+            # Check if selected pin is free
+            pin_is_free = await async_check_if_pin_is_used(
+                hass=self.hass, pin=self.data[CONF_PIN]
+            )
+            if pin_is_free is False:
+                errors[CONF_PIN] = "pin_used"
+
+            if not errors:
+                # Create the entity
+                return self.async_create_entry(
+                    title="GPIO " + str(self.data[CONF_PIN]) + " PWM " + CONF_FAN,
+                    data=self.data,
+                )
+
+        # Menu to display
+        return self.async_show_form(
+            step_id="fan", data_schema=DATA_SCHEMA_ConfigFlowFan, errors=errors
+        )

--- a/custom_components/rpi_gpio_pwm/config_flow.py
+++ b/custom_components/rpi_gpio_pwm/config_flow.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_HOST,
@@ -157,14 +157,14 @@ class GPIOPWMConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Invoke when a user initiates a flow via the user interface."""
         return self.async_show_menu(
             step_id="user",
             menu_options=["light", "fan"],
         )
 
-    async def async_step_light(self, user_input: dict | None = None) -> FlowResult:
+    async def async_step_light(self, user_input: dict | None = None) -> ConfigFlowResult:
         """Invoke when a user initiates a flow via the user interface."""
         errors: dict[str, str] = {}
 
@@ -193,7 +193,7 @@ class GPIOPWMConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="light", data_schema=DATA_SCHEMA_ConfigFlowLight, errors=errors
         )
 
-    async def async_step_fan(self, user_input: dict | None = None) -> FlowResult:
+    async def async_step_fan(self, user_input: dict | None = None) -> ConfigFlowResult:
         """Invoke when a user initiates a flow via the user interface."""
         errors: dict[str, str] = {}
 
@@ -225,7 +225,7 @@ class GPIOPWMConfigFlow(ConfigFlow, domain=DOMAIN):
     # Declare optionFlow
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry):
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Get options flow for this handler."""
         return GPIOPWMOptionsFlow(config_entry)
 

--- a/custom_components/rpi_gpio_pwm/const.py
+++ b/custom_components/rpi_gpio_pwm/const.py
@@ -1,0 +1,12 @@
+"""The rpi_gpio_pwm constants."""
+
+CONF_FANS = "fans"
+CONF_FREQUENCY = "frequency"
+CONF_LEDS = "leds"
+CONF_PIN = "pin"
+
+
+DEFAULT_BRIGHTNESS = 255
+DEFAULT_FAN_PERCENTAGE = 100
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 8888

--- a/custom_components/rpi_gpio_pwm/const.py
+++ b/custom_components/rpi_gpio_pwm/const.py
@@ -1,12 +1,24 @@
 """The rpi_gpio_pwm constants."""
 
+from homeassistant.const import Platform
+
 CONF_FANS = "fans"
+CONF_FAN = "fan"
 CONF_FREQUENCY = "frequency"
 CONF_LEDS = "leds"
+CONF_LIGHT = "light"
 CONF_PIN = "pin"
 
 
 DEFAULT_BRIGHTNESS = 255
 DEFAULT_FAN_PERCENTAGE = 100
+DEFAULT_FREQUENCY = 100
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8888
+DOMAIN = "rpi_gpio_pwm"
+
+
+PLATFORMS: list[Platform] = [
+    Platform.FAN,
+    Platform.LIGHT,
+]

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-):
+) -> None:
     """Set up fan from the ConfigEntry configuration created in the integrations UI."""
     pin = config_entry.data.get(CONF_PIN)
     opt_args = {}

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -72,7 +72,8 @@ def setup_platform(
         fan = PwmSimpleFan(
             fan=PWMOutputDevice(pin, **opt_args),
             name=fan_conf[CONF_NAME],
-            unique_id=fan_conf[CONF_UNIQUE_ID]
+            unique_id=fan_conf[CONF_UNIQUE_ID],
+            hass=hass,
         )
         fans.append(fan)
 
@@ -82,8 +83,10 @@ def setup_platform(
 class PwmSimpleFan(FanEntity, RestoreEntity):
     """Representation of a simple PWM FAN."""
 
-    def __init__(self, fan, name, unique_id):
+    def __init__(self, fan, name, unique_id, hass):
         """Initialize PWM FAN."""
+        self._hass = hass
+        self._attr_has_entity_name = True
         self._fan = fan
         self._name = name
         self._unique_id = unique_id

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -69,10 +69,11 @@ def setup_platform(
         pin = fan_conf[CONF_PIN]
         opt_args = {}
         opt_args["pin_factory"] = PiGPIOFactory(host=fan_conf[CONF_HOST], port= fan_conf[CONF_PORT])
-        if CONF_UNIQUE_ID in fan_conf:
-            fan = PwmSimpleFan(PWMOutputDevice(pin, **opt_args), fan_conf[CONF_NAME], fan_conf[CONF_UNIQUE_ID])
-        else:
-            fan = PwmSimpleFan(PWMOutputDevice(pin, **opt_args), fan_conf[CONF_NAME])
+        fan = PwmSimpleFan(
+            fan=PWMOutputDevice(pin, **opt_args),
+            name=fan_conf[CONF_NAME],
+            unique_id=fan_conf[CONF_UNIQUE_ID]
+        )
         fans.append(fan)
 
     add_entities(fans)

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -1,11 +1,11 @@
 """Support for Fan that can be controlled using PWM."""
+
 from __future__ import annotations
 
 import logging
 
 from gpiozero import PWMOutputDevice
 from gpiozero.pins.pigpio import PiGPIOFactory
-
 import voluptuous as vol
 
 from homeassistant.components.fan import (
@@ -14,22 +14,28 @@ from homeassistant.components.fan import (
     FanEntityFeature,
     FanEntity,
 )
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_NAME, STATE_ON, CONF_UNIQUE_ID
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_UNIQUE_ID,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from .const import (
+    CONF_FANS,
+    CONF_PIN,
+    DEFAULT_FAN_PERCENTAGE,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+)
+
 _LOGGER = logging.getLogger(__name__)
-
-CONF_FANS = "fans"
-CONF_PIN = "pin"
-
-DEFAULT_PERCENTAGE = 100
-
-DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 8888
 
 SUPPORT_SIMPLE_FAN = FanEntityFeature.SET_SPEED
 
@@ -81,7 +87,7 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         self._name = name
         self._unique_id = unique_id
         self._is_on = False
-        self._percentage = DEFAULT_PERCENTAGE
+        self._percentage = DEFAULT_FAN_PERCENTAGE
 
     async def async_added_to_hass(self):
         """Handle entity about to be added to hass event."""
@@ -89,7 +95,7 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         if last_state := await self.async_get_last_state():
             self._is_on = last_state.state == STATE_ON
             self._percentage = last_state.attributes.get(
-                "percentage", DEFAULT_PERCENTAGE
+                "percentage", DEFAULT_FAN_PERCENTAGE
             )
 
     @property
@@ -145,3 +151,4 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         self._fan.value = self._percentage / 100
         self._is_on = True
         self.schedule_update_ha_state()
+

--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -12,8 +12,8 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
-    SUPPORT_TRANSITION,
     LightEntity,
+    LightEntityFeature,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_NAME, STATE_ON, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
@@ -33,7 +33,7 @@ DEFAULT_BRIGHTNESS = 255
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8888
 
-SUPPORT_SIMPLE_LED = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+SUPPORT_SIMPLE_LED = SUPPORT_BRIGHTNESS | LightEntityFeature.TRANSITION
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -95,7 +95,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-):
+) -> None:
     """Set up light from the ConfigEntry configuration created in the integrations UI."""
     pin = config_entry.data.get(CONF_PIN)
     opt_args = {}

--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -1,11 +1,11 @@
 """Support for LED lights that can be controlled using PWM."""
+
 from __future__ import annotations
 
 import logging
 
 from gpiozero import PWMLED
 from gpiozero.pins.pigpio import PiGPIOFactory
-
 import voluptuous as vol
 
 from homeassistant.components.light import (
@@ -15,23 +15,29 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
 )
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_NAME, STATE_ON, CONF_UNIQUE_ID
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_UNIQUE_ID,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from .const import (
+    CONF_FREQUENCY,
+    CONF_LEDS,
+    CONF_PIN,
+    DEFAULT_BRIGHTNESS,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+)
+
 _LOGGER = logging.getLogger(__name__)
-
-CONF_LEDS = "leds"
-CONF_PIN = "pin"
-CONF_FREQUENCY = "frequency"
-
-DEFAULT_BRIGHTNESS = 255
-
-DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 8888
 
 SUPPORT_SIMPLE_LED = LightEntityFeature.TRANSITION
 COLORMODE = ColorMode.BRIGHTNESS
@@ -156,3 +162,4 @@ class PwmSimpleLed(LightEntity, RestoreEntity):
 def _from_hass_brightness(brightness):
     """Convert Home Assistant brightness units to percentage."""
     return brightness / 255
+

--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
-    SUPPORT_BRIGHTNESS,
+    ColorMode,
     LightEntity,
     LightEntityFeature,
 )
@@ -33,7 +33,8 @@ DEFAULT_BRIGHTNESS = 255
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8888
 
-SUPPORT_SIMPLE_LED = SUPPORT_BRIGHTNESS | LightEntityFeature.TRANSITION
+SUPPORT_SIMPLE_LED = LightEntityFeature.TRANSITION
+COLORMODE = ColorMode.BRIGHTNESS
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -121,6 +122,16 @@ class PwmSimpleLed(LightEntity, RestoreEntity):
     def brightness(self):
         """Return the brightness property."""
         return self._brightness
+
+    @property
+    def supported_color_modes(self):
+        """Return the flag supported_color_modes property."""
+        return {COLORMODE}
+
+    @property
+    def color_mode(self):
+        """Return the color_mode property."""
+        return COLORMODE
 
     @property
     def supported_features(self):

--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -75,10 +75,11 @@ def setup_platform(
         if CONF_FREQUENCY in led_conf:
             opt_args["frequency"] = led_conf[CONF_FREQUENCY]
         opt_args["pin_factory"] = PiGPIOFactory(host=led_conf[CONF_HOST], port= led_conf[CONF_PORT])
-        if CONF_UNIQUE_ID in led_conf:
-            led = PwmSimpleLed(PWMLED(pin, **opt_args), led_conf[CONF_NAME], led_conf[CONF_UNIQUE_ID])
-        else:
-            led = PwmSimpleLed(PWMLED(pin, **opt_args), led_conf[CONF_NAME])
+        led = PwmSimpleLed(
+            led=PWMLED(pin, **opt_args),
+            name=led_conf[CONF_NAME],
+            unique_id=led_conf[CONF_UNIQUE_ID]
+        )
         leds.append(led)
 
     add_entities(leds)

--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -78,7 +78,8 @@ def setup_platform(
         led = PwmSimpleLed(
             led=PWMLED(pin, **opt_args),
             name=led_conf[CONF_NAME],
-            unique_id=led_conf[CONF_UNIQUE_ID]
+            unique_id=led_conf[CONF_UNIQUE_ID],
+            hass=hass,
         )
         leds.append(led)
 
@@ -88,8 +89,10 @@ def setup_platform(
 class PwmSimpleLed(LightEntity, RestoreEntity):
     """Representation of a simple one-color PWM LED."""
 
-    def __init__(self, led, name, unique_id):
+    def __init__(self, led, name, unique_id, hass):
         """Initialize one-color PWM LED."""
+        self._hass = hass
+        self._attr_has_entity_name = True
         self._led = led
         self._name = name
         self._unique_id = unique_id

--- a/custom_components/rpi_gpio_pwm/manifest.json
+++ b/custom_components/rpi_gpio_pwm/manifest.json
@@ -2,6 +2,7 @@
   "domain": "rpi_gpio_pwm",
   "name": "Raspberry Pi GPIO PWM",
   "codeowners": ["@regevbr", "@antonverburg"],
+  "config_flow": true,
   "documentation": "https://github.com/RedMeKool/HA-Raspberry-pi-GPIO-PWM",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/RedMeKool/HA-Raspberry-pi-GPIO-PWM/issues",

--- a/custom_components/rpi_gpio_pwm/translations/en.json
+++ b/custom_components/rpi_gpio_pwm/translations/en.json
@@ -1,0 +1,53 @@
+
+{
+    "title": "RPI GPIO PWM",
+    "config": {
+        "flow_title": "Rpi_GPIO_PWM configuration",
+        "error": {
+            "pin_used": "The selected pin is already in use."
+        },
+        "step": {
+            "user": {
+               "menu_options": {
+                    "light": "Configure a light",
+                    "fan": "Configure a fan"
+                }
+            },
+            "light": {
+              "title": "Configuration of a light",
+              "description": "Configuration panel for a light throuth GPIO",
+              "data": {
+                  "name": "Name",
+                  "pin": "PIN",
+                  "host": "Host",
+                  "port": "Port",
+                  "frequency": "Frequency"
+              },
+              "data_description": {
+                  "name": "Name for your light",
+                  "pin": "The pin connected to the LED",
+                  "host": "The remote host address for the GPIO driver",
+                  "port": "The port on which the GPIO driver is listening",
+                  "frequency": "The PWM frequency for light config"
+              }
+            },
+            "fan": {
+                "title": "Configuration of a Fan",
+                "description": "Configuration panel for a fan throuth GPIO",
+                "data": {
+                    "name": "Name",
+                    "pin": "PIN",
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "data_description": {
+                    "name": "Name for your fan",
+                    "pin": "The pin connected to the FAN",
+                    "host": "The remote host address for the GPIO driver",
+                    "port": "The port on which the GPIO driver is listening"
+                }
+            }
+        }
+    }
+  }
+  

--- a/custom_components/rpi_gpio_pwm/translations/en.json
+++ b/custom_components/rpi_gpio_pwm/translations/en.json
@@ -48,6 +48,36 @@
                 }
             }
         }
+    },
+    "options": {
+      "flow_title": "Rpi_GPIO_PWM RE-configuration",
+      "error": {
+          "pin_used": "The selected pin is already in use.",
+          "fan_bad_EntityID_format": "Bad Entity_ID format. Please format like 'fan.name_you_want'",
+          "light_bad_EntityID_format": "Bad Entity_ID format. Please format like 'light.name_you_want'"
+      },
+      "step": {
+          "init": {
+              "title": "RE-Configuration of a device",
+              "description": "Configuration panel for a device throuth GPIO",
+              "data": {
+                  "name": "Name",
+                  "entity_id": "Entity ID",
+                  "pin": "PIN",
+                  "host": "Host",
+                  "port": "Port",
+                  "frequency": "Frequency"
+              },
+              "data_description": {
+                  "name": "Name for your device",
+                  "entity_id": "Entity ID for your device",
+                  "pin": "The pin connected to the device",
+                  "host": "The remote host address for the GPIO driver",
+                  "port": "The port on which the GPIO driver is listening",
+                  "frequency": "The PWM frequency for light config"
+              }
+          }
+      }
     }
   }
   

--- a/info.md
+++ b/info.md
@@ -47,7 +47,7 @@ fan:
 
 - **pin** integer *(REQUIRED)*: The pin connected to the LED as a list for light config or the pin connected to the FAN for fan config..
 
-- **unique_id** string *(optional)*: An ID that uniquely identifies this LED or FAN. Set this to a unique value to allow customization through the UI.
+- **unique_id** string *(REQUIRED)*: An ID that uniquely identifies this LED or FAN. Set this to a unique value to allow customization through the UI.
 
 - **frequency** integer *(optional, default: 100)*: The PWM frequency for light config.
 


### PR DESCRIPTION
I added the ConfigFlow to the configuration step. Thus it is possible to configure or re-configure an entity (fan or light) directly from the "add integration" menu without needing to configure in `configuration.yaml`

Do not hesitate to ask me for any information. The code is still fresh in my head I can explain each step