### PR TITLE
Change PLATFORMS const

### DIFF
--- a/custom_components/rpi_gpio_pwm/__init__.py
+++ b/custom_components/rpi_gpio_pwm/__init__.py
@@ -3,7 +3,7 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN, PLATFORMS, PLATFORMS_FAN, PLATFORMS_LIGHT
 
 
 # Transform the configEntry from config_flow into an entity
@@ -23,7 +23,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Propagates the configEntry to all platforms declared in the integration
     # This creates each HA object for each platform your device requires.
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    if hass_data["platform"] == "fan":
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS_FAN)
+    if hass_data["platform"] == "light":
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS_LIGHT)
 
     return True
 

--- a/custom_components/rpi_gpio_pwm/const.py
+++ b/custom_components/rpi_gpio_pwm/const.py
@@ -22,3 +22,9 @@ PLATFORMS: list[Platform] = [
     Platform.FAN,
     Platform.LIGHT,
 ]
+PLATFORMS_FAN: list[Platform] = [
+    Platform.FAN,
+]
+PLATFORMS_LIGHT: list[Platform] = [
+    Platform.LIGHT,
+]


### PR DESCRIPTION
### Update async_setup_entry to avoid conflict with fan and light creating at same time

The problem came from a conflict in the creation of fan and light entities which was done on the same PIN during configuration with ConfigFlow.

![Elia 2024-06-14 à 12 47 51](https://github.com/RedMeKool/HA-Raspberry-pi-GPIO-PWM/assets/21007415/1ad44039-8470-4bab-a454-cae3e0618448)

The easy solution would have been to remove the possibility of creating lights and only keep the creation of fans. But I didn't want to remove this functionality which was part of the original custom component created by @RedMeKool.
My goal is to help and not to distort the work of others.

This is why I am offering you this solution which may not be the cleanest, although I did my best to make it so, but which has the merit of working this time.

So this should solve this issue. https://github.com/RedMeKool/HA-Raspberry-pi-GPIO-PWM/issues/63

Sorry if it took me a while to resolve the problem.
I'm not a developer and I haven't been able to get into it full time

I hope this update will make it easier for you to install this custom component!

See you soon. Maybe ^^