### PR TITLE
Update-for-Home-Assistant-Core-2024.8-complient

### DIFF
--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -39,7 +39,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_SIMPLE_FAN = FanEntityFeature.SET_SPEED
+SUPPORT_SIMPLE_FAN = (FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -168,7 +168,7 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         """Flag supported features."""
         return SUPPORT_SIMPLE_FAN
 
-    def turn_on(self, percentage: None, preset_mode: None, **kwargs) -> None:
+    def turn_on(self, percentage: Optional[int] = None, preset_mode: Optional[str] = None, **kwargs: Any) -> None:
         """Turn on the fan."""
         if percentage is not None:
             self._percentage = percentage
@@ -178,7 +178,7 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         self._is_on = True
         self.schedule_update_ha_state()
 
-    def turn_off(self, **kwargs) -> None:
+    def turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         if self.is_on:
             self._fan.off()

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -39,7 +39,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_SIMPLE_FAN = (FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF)
+SUPPORT_SIMPLE_FAN = (
+    FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -168,7 +170,12 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         """Flag supported features."""
         return SUPPORT_SIMPLE_FAN
 
-    def turn_on(self, percentage: Optional[int] = None, preset_mode: Optional[str] = None, **kwargs: Any) -> None:
+    def turn_on(
+        self,
+        percentage: Optional[int] = None,
+        preset_mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
         """Turn on the fan."""
         if percentage is not None:
             self._percentage = percentage
@@ -191,3 +198,4 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         self._fan.value = self._percentage / 100
         self._is_on = True
         self.schedule_update_ha_state()
+

--- a/custom_components/rpi_gpio_pwm/fan.py
+++ b/custom_components/rpi_gpio_pwm/fan.py
@@ -170,12 +170,7 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         """Flag supported features."""
         return SUPPORT_SIMPLE_FAN
 
-    def turn_on(
-        self,
-        percentage: Optional[int] = None,
-        preset_mode: Optional[str] = None,
-        **kwargs: Any,
-    ) -> None:
+    def turn_on(self, percentage: None, preset_mode: None, **kwargs) -> None:
         """Turn on the fan."""
         if percentage is not None:
             self._percentage = percentage
@@ -185,7 +180,7 @@ class PwmSimpleFan(FanEntity, RestoreEntity):
         self._is_on = True
         self.schedule_update_ha_state()
 
-    def turn_off(self, **kwargs: Any) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn the fan off."""
         if self.is_on:
             self._fan.off()


### PR DESCRIPTION
Added two new flags to FanEntityFeature for HA 2024.8
As noted in the following [post](https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/) it is now necessary to add two flags TURN_ON and TURN_OFF.
This change will remove the warning from the logs
![Elia 2024-08-09 à 16 47 21](https://github.com/user-attachments/assets/607bb6e4-38e4-4b92-be38-8ab7b994878a)
