### PR TITLE
return DEFAULT_BRIGHTNESS if brightness is 'none'

### DIFF
--- a/custom_components/rpi_gpio_pwm/light.py
+++ b/custom_components/rpi_gpio_pwm/light.py
@@ -203,4 +203,4 @@ class PwmSimpleLed(LightEntity, RestoreEntity):
 
 def _from_hass_brightness(brightness):
     """Convert Home Assistant brightness units to percentage."""
-    return brightness / 255
+    return brightness / 255 or DEFAULT_BRIGHTNESS


### PR DESCRIPTION
If brightness as never set before I got an error by dividing 'none' by 255. So I return the DEFAULT_BRIGHTNESS if as default.